### PR TITLE
Fixed the function that returns the current month for the credit card descriptor

### DIFF
--- a/WePay/Descriptors/WPCreditCardDescriptor.m
+++ b/WePay/Descriptors/WPCreditCardDescriptor.m
@@ -81,16 +81,27 @@
 
 
 - (NSInteger) currentYear {
+#ifdef __IPHONE_8_0
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSDateComponents *components = [gregorian components:NSCalendarUnitYear fromDate:[NSDate date]];
+#else
     NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     NSDateComponents *components = [gregorian components:NSYearCalendarUnit fromDate:[NSDate date]];
+#endif
+                      
     return [components year];
 }
 
-
 - (NSInteger) currentMonth {
+#ifdef __IPHONE_8_0
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSDateComponents *components = [gregorian components:NSCalendarUnitMonth fromDate:[NSDate date]];
+#else
     NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-    NSDateComponents *components = [gregorian components:NSYearCalendarUnit fromDate:[NSDate date]];
-    return [components month];
+    NSDateComponents *components = [gregorian components:NSMonthCalendarUnit fromDate:[NSDate date]];
+#endif
+                      
+  return [components month];
 }
 
 


### PR DESCRIPTION
Fix compiler warnings: use non-deprecated constants
