### PR TITLE
Use extern string definitions for kWP*

### DIFF
--- a/WePay/WePay.h
+++ b/WePay/WePay.h
@@ -21,20 +21,20 @@
 @class WPPaymentToken;
 
 // Environments
-static NSString* const kWPEnvironmentStage = @"stage";
-static NSString* const kWPEnvironmentProduction = @"production";
+extern NSString * const kWPEnvironmentStage;
+extern NSString * const kWPEnvironmentProduction;
 
 // Payment Methods
-static NSString* const kWPPaymentMethodSwipe = @"Swipe";
-static NSString* const kWPPaymentMethodManual = @"Manual";
+extern NSString * const kWPPaymentMethodSwipe;
+extern NSString * const kWPPaymentMethodManual;
 
 // Card Reader status
-static NSString* const kWPCardReaderStatusNotConnected = @"card reader not connected";
-static NSString* const kWPCardReaderStatusConnected = @"card reader connected";
-static NSString* const kWPCardReaderStatusWaitingForSwipe = @"waiting for swipe";
-static NSString* const kWPCardReaderStatusSwipeDetected = @"swipe detected";
-static NSString* const kWPCardReaderStatusTokenizing = @"tokenizing";
-static NSString* const kWPCardReaderStatusStopped = @"stopped";
+extern NSString * const kWPCardReaderStatusNotConnected;
+extern NSString * const kWPCardReaderStatusConnected;
+extern NSString * const kWPCardReaderStatusWaitingForSwipe;
+extern NSString * const kWPCardReaderStatusSwipeDetected;
+extern NSString * const kWPCardReaderStatusTokenizing;
+extern NSString * const kWPCardReaderStatusStopped;
 
 
 /** \protocol WPTokenizationDelegate
@@ -241,4 +241,3 @@ static NSString* const kWPCardReaderStatusStopped = @"stopped";
 ///@}
 
 @end
-

--- a/WePay/WePay.m
+++ b/WePay/WePay.m
@@ -53,7 +53,7 @@ NSString * const kWPCardReaderStatusStopped = @"stopped";
     if (self = [super init]) {
         self.config = config;
     }
-
+    
     return self;
 }
 
@@ -65,7 +65,7 @@ NSString * const kWPCardReaderStatusStopped = @"stopped";
         if (!self.wePayManual) {
             self.wePayManual = [[WePay_Manual alloc] initWithConfig:self.config];
         }
-
+        
         [self.wePayManual tokenizeManualPaymentInfo:paymentInfo
                                tokenizationDelegate:tokenizationDelegate
                                           sessionId:[self getSessionId]];
@@ -73,7 +73,7 @@ NSString * const kWPCardReaderStatusStopped = @"stopped";
         if (!self.wePayCardReader) {
             self.wePayCardReader = [[WePay_CardReader alloc] initWithConfig:self.config];
         }
-
+        
         [self.wePayCardReader tokenizeSwipedPaymentInfo:paymentInfo
                                tokenizationDelegate:tokenizationDelegate
                                           sessionId:[self getSessionId]];
@@ -92,7 +92,7 @@ NSString * const kWPCardReaderStatusStopped = @"stopped";
     if (!self.wePayCardReader) {
         self.wePayCardReader = [[WePay_CardReader alloc] initWithConfig:self.config];
     }
-
+    
     [self.wePayCardReader startCardReaderForReadingWithCardReaderDelegate:cardReaderDelegate];
 }
 
@@ -102,7 +102,7 @@ NSString * const kWPCardReaderStatusStopped = @"stopped";
     if (!self.wePayCardReader) {
         self.wePayCardReader = [[WePay_CardReader alloc] initWithConfig:self.config];
     }
-
+    
     [self.wePayCardReader startCardReaderForTokenizingWithCardReaderDelegate:cardReaderDelegate
                                                     tokenizationDelegate:tokenizationDelegate
                                                                sessionId:[self getSessionId]];
@@ -128,7 +128,7 @@ NSString * const kWPCardReaderStatusStopped = @"stopped";
     if (!self.wePayCheckout) {
         self.wePayCheckout = [[WePay_Checkout alloc] initWithConfig:self.config];
     }
-
+    
     [self.wePayCheckout storeSignatureImage:image
                             forCheckoutId:checkoutId
                          checkoutDelegate:checkoutDelegate];
@@ -143,7 +143,7 @@ NSString * const kWPCardReaderStatusStopped = @"stopped";
     if (!self.riskHelper) {
         self.riskHelper = [[WPRiskHelper alloc] initWithConfig:self.config];
     }
-
+    
     return [self.riskHelper sessionId];
 }
 

--- a/WePay/WePay.m
+++ b/WePay/WePay.m
@@ -18,6 +18,23 @@
 #import "WePay_Checkout.h"
 #import "WPRiskHelper.h"
 
+
+// Environments
+NSString * const kWPEnvironmentStage = @"stage";
+NSString * const kWPEnvironmentProduction = @"production";
+
+// Payment Methods
+NSString * const kWPPaymentMethodSwipe = @"Swipe";
+NSString * const kWPPaymentMethodManual = @"Manual";
+
+// Card Reader status
+NSString * const kWPCardReaderStatusNotConnected = @"card reader not connected";
+NSString * const kWPCardReaderStatusConnected = @"card reader connected";
+NSString * const kWPCardReaderStatusWaitingForSwipe = @"waiting for swipe";
+NSString * const kWPCardReaderStatusSwipeDetected = @"swipe detected";
+NSString * const kWPCardReaderStatusTokenizing = @"tokenizing";
+NSString * const kWPCardReaderStatusStopped = @"stopped";
+
 @interface WePay ()
 
 @property(nonatomic, strong) WePay_CardReader *wePayCardReader;
@@ -36,7 +53,7 @@
     if (self = [super init]) {
         self.config = config;
     }
-    
+
     return self;
 }
 
@@ -75,7 +92,7 @@
     if (!self.wePayCardReader) {
         self.wePayCardReader = [[WePay_CardReader alloc] initWithConfig:self.config];
     }
-    
+
     [self.wePayCardReader startCardReaderForReadingWithCardReaderDelegate:cardReaderDelegate];
 }
 
@@ -85,7 +102,7 @@
     if (!self.wePayCardReader) {
         self.wePayCardReader = [[WePay_CardReader alloc] initWithConfig:self.config];
     }
-    
+
     [self.wePayCardReader startCardReaderForTokenizingWithCardReaderDelegate:cardReaderDelegate
                                                     tokenizationDelegate:tokenizationDelegate
                                                                sessionId:[self getSessionId]];


### PR DESCRIPTION
Without the string constants defined as `extern` I was running into linker issues `Undefined symbols for architecture arm64:`. This appears to affect SDK installations via CocoaPods.
