### PR TITLE
Use enums in place of `kWPEnvironment`, `kWPCardReaderStatus`, and `kWPPaymentMethod` constants

### DIFF
--- a/WePay/Internal/WPClient.m
+++ b/WePay/Internal/WPClient.m
@@ -75,13 +75,13 @@ static WPConfig *config;
 {
     NSString *serverUrl = nil;
     // Use environment config to set the endpoint
-    if ([kWPEnvironmentStage compare:config.environment options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+    if (config.environment == WPEnvironmentStage) {
         serverUrl = @"https://stage.wepayapi.com/v2/";
-    } else if ([kWPEnvironmentProduction compare:config.environment options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+    } else if (config.environment == WPEnvironmentProduction) {
         serverUrl = @"https://wepayapi.com/v2/";
     } else {
         // Use @"https://vm.wepay.com/v2/" for vm
-        serverUrl = config.environment;
+        serverUrl = config.customEnvironmentUrl;
     }
 
 

--- a/WePay/Internal/WePay_CardReader.m
+++ b/WePay/Internal/WePay_CardReader.m
@@ -124,7 +124,7 @@
     self.roamDeviceManager = nil;
 
     // inform delegate
-    [self informExternalCardReader:kWPCardReaderStatusStopped];
+    [self informExternalCardReader:WPCardReaderStatusStopped];
 }
 
 
@@ -185,7 +185,7 @@
         [self waitForSwipe];
     } else {
         // Wait a few seconds for the swiper to be detected, otherwise announce not connected
-        [self performSelector:@selector(informExternalCardReader:) withObject:kWPCardReaderStatusNotConnected afterDelay:3.5];
+        [self performSelector:@selector(informExternalCardReader:) withObject:WPCardReaderStatusNotConnected afterDelay:3.5];
     }
 }
 
@@ -200,10 +200,10 @@
     [tmgr waitForMagneticCardSwipe: ^(RUAProgressMessage messageType, NSString* additionalMessage) {
                                         switch (messageType) {
                                             case RUAProgressMessageWaitingforCardSwipe:
-                                                [self informExternalCardReader:kWPCardReaderStatusWaitingForSwipe];
+                                                [self informExternalCardReader:WPCardReaderStatusWaitingForSwipe];
                                                 break;
                                             case RUAProgressMessageSwipeDetected:
-                                                [self informExternalCardReader:kWPCardReaderStatusSwipeDetected];
+                                                [self informExternalCardReader:WPCardReaderStatusSwipeDetected];
                                                 break;
                                             default:
                                                 // Do nothing on progress, react to the response when it comes
@@ -299,7 +299,7 @@
     // cancel any scheduled notifications - kWPSwiperStatusNotConnected
     [NSObject cancelPreviousPerformRequestsWithTarget:self
                                              selector:@selector(informExternalCardReader:)
-                                               object:kWPCardReaderStatusNotConnected];
+                                               object:WPCardReaderStatusNotConnected];
 
     
     // tell RUA to stop waiting for swipe
@@ -335,7 +335,7 @@
         // tokenize if requested
         if(self.swiperShouldTokenize && self.externalTokenizationDelegate) {
             // inform external
-            [self informExternalCardReader:kWPCardReaderStatusTokenizing];
+            [self informExternalCardReader:WPCardReaderStatusTokenizing];
 
             // tokenize
             [self tokenizeSwipedPaymentInfo:paymentInfo
@@ -432,12 +432,12 @@
     // Cancel any scheduled calls for swiper not connected
     [NSObject cancelPreviousPerformRequestsWithTarget:self
                                              selector:@selector(informExternalCardReader:)
-                                               object:kWPCardReaderStatusNotConnected];
+                                               object:WPCardReaderStatusNotConnected];
     
     // If we should wait for swipe
     if (self.swiperShouldWaitForSwipe) {
         // Inform external delegate
-        [self informExternalCardReader:kWPCardReaderStatusConnected];
+        [self informExternalCardReader:WPCardReaderStatusConnected];
 
         // Check and wait - the delay is to let the swiper get charged
         [self performSelector:@selector(checkAndWaitForSwipe) withObject:nil afterDelay:2.0];
@@ -450,7 +450,7 @@
     
     // Inform external delegate if we should wait for swipe
     if (self.swiperShouldWaitForSwipe) {
-        [self informExternalCardReader:kWPCardReaderStatusNotConnected];
+        [self informExternalCardReader:WPCardReaderStatusNotConnected];
     }
     
     // Stop waiting for swipe
@@ -472,7 +472,7 @@
 
 #pragma mark - inform external
 
-- (void) informExternalCardReader:(NSString *)status
+- (void) informExternalCardReader:(enum WPCardReaderStatus)status
 {
     // If the external delegate is listening for status updates, send it
     if (self.externalCardReaderDelegate && [self.externalCardReaderDelegate respondsToSelector:@selector(cardReaderDidChangeStatus:)]) {

--- a/WePay/Models/WPConfig.h
+++ b/WePay/Models/WPConfig.h
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSInteger, WPEnvironment) {
 /**
  *  The URL of the environment to use when environment is set to WPEnvironmentCustom.
  */
-@property (nonatomic, assign, readonly) NSString *customEnvironmentUrl;
+@property (nonatomic, strong, readonly) NSString *customEnvironmentUrl;
 
 /**
  *  Determines if we should use location services. Defaults to NO.

--- a/WePay/Models/WPConfig.h
+++ b/WePay/Models/WPConfig.h
@@ -70,7 +70,7 @@ typedef NS_ENUM(NSInteger, WPEnvironment) {
  *  The designated initializer
  *
  *  @param clientId                             Your WePay clientId.
- *  @param environment                          The environment to be used, one of (WPEnvironmentStage, kWPEnvironmentProduction).
+ *  @param environment                          The environment to be used, one of (WPEnvironmentStage, WPEnvironmentProduction, WPEnvironmentCustom).
  *  @param customEnvironmentUrl                 The url to use when environment is set to WPEnvironmentCustom
  *  @param useLocation                          Flag to determine if we should use location services.
  *  @param restartCardReaderAfterSuccess        Flag to determine if the card reader should automatically restart after a successful read.

--- a/WePay/Models/WPConfig.h
+++ b/WePay/Models/WPConfig.h
@@ -8,6 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
+// Environments
+typedef NS_ENUM(NSInteger, WPEnvironment) {
+    WPEnvironmentStage,
+    WPEnvironmentProduction,
+    WPEnvironmentCustom // Set customEnvironmentUrl when using this option
+};
+
 /**
  * The configuration object used for initializing a \ref WePay instance.
  */
@@ -19,9 +26,14 @@
 @property (nonatomic, strong, readonly) NSString *clientId;
 
 /**
- *  The environment to be used, one of (staging, production)
+ *  The environment to be used, one of (WPEnvironmentStage, WPEnvironmentProduction, WPEnvironmentCustom). You must set customEnvironmentUrl if using WPEnvironmentCustom.
  */
-@property (nonatomic, strong, readonly) NSString *environment;
+@property (nonatomic, assign, readonly) enum WPEnvironment environment;
+
+/**
+ *  The URL of the environment to use when environment is set to WPEnvironmentCustom.
+ */
+@property (nonatomic, assign, readonly) NSString *customEnvironmentUrl;
 
 /**
  *  Determines if we should use location services. Defaults to NO.
@@ -47,18 +59,19 @@
  *  A convenience initializer
  *
  *  @param clientId    Your WePay clientId.
- *  @param environment The environment to be used, one of (kWPEnvironmentStage, kWPEnvironmentProduction).
+ *  @param environment The environment to be used, one of (WPEnvironmentStage, WPEnvironmentProduction). You must use the designated initializer when delcaring WPEnvironmentCustom.
  *
  *  @return A \ref WPConfig instance which can be used to initialize a \ref WePay instance.
  */
 - (instancetype) initWithClientId:(NSString *)clientId
-                      environment:(NSString *)environment;
+                      environment:(enum WPEnvironment)environment;
 
 /**
  *  The designated initializer
  *
  *  @param clientId                             Your WePay clientId.
- *  @param environment                          The environment to be used, one of (kWPEnvironmentStage, kWPEnvironmentProduction).
+ *  @param environment                          The environment to be used, one of (WPEnvironmentStage, kWPEnvironmentProduction).
+ *  @param customEnvironmentUrl                 The url to use when environment is set to WPEnvironmentCustom
  *  @param useLocation                          Flag to determine if we should use location services.
  *  @param restartCardReaderAfterSuccess        Flag to determine if the card reader should automatically restart after a successful read.
  *  @param restartCardReaderAfterGeneralError   Flag to determine if the card reader should automatically restart after a general error (domain:kWPErrorCategoryCardReader, errorCode:WPErrorCardReaderGeneralError).
@@ -67,7 +80,8 @@
  *  @return A \ref WPConfig instance which can be used to initialize a \ref WePay instance.
  */
 - (instancetype) initWithClientId:(NSString *)clientId
-                      environment:(NSString *)environment
+                      environment:(enum WPEnvironment)environment
+             customEnvironmentUrl:(NSString *)customEnvironmentUrl
                       useLocation:(BOOL)useLocation
     restartCardReaderAfterSuccess:(BOOL)restartCardReaderAfterSuccess
 restartCardReaderAfterGeneralError:(BOOL)restartCardReaderAfterGeneralError

--- a/WePay/Models/WPConfig.m
+++ b/WePay/Models/WPConfig.m
@@ -11,7 +11,7 @@
 @interface WPConfig ()
 
 @property (nonatomic, strong, readwrite) NSString *clientId;
-@property (nonatomic, strong, readwrite) NSString *environment;
+@property (nonatomic, assign, readwrite) enum WPEnvironment environment;
 @end
 
 
@@ -19,10 +19,13 @@
 
 
 - (instancetype) initWithClientId:(NSString *)clientId
-                      environment:(NSString *)environment
+                      environment:(enum WPEnvironment)environment
 {
+    NSAssert(environment != WPEnvironmentCustom, @"You must use the designated initializer when using WPEnvironmentCustom.");
+    
     return [self initWithClientId:clientId
                       environment:environment
+             customEnvironmentUrl:nil
                       useLocation:NO
     restartCardReaderAfterSuccess:NO
 restartCardReaderAfterGeneralError:YES
@@ -31,12 +34,18 @@ restartCardReaderAfterOtherErrors: NO];
 
 
 - (instancetype) initWithClientId:(NSString *)clientId
-                      environment:(NSString *)environment
+                      environment:(enum WPEnvironment)environment
+             customEnvironmentUrl:(NSString *)customEnvironmentUrl
                       useLocation:(BOOL)useLocation
     restartCardReaderAfterSuccess:(BOOL)restartCardReaderAfterSuccess
 restartCardReaderAfterGeneralError:(BOOL)restartCardReaderAfterGeneralError
 restartCardReaderAfterOtherErrors:(BOOL)restartCardReaderAfterOtherErrors
 {
+    
+    
+    NSAssert((environment != WPEnvironmentCustom) || (environment == WPEnvironmentCustom && customEnvironmentUrl != nil),
+             @"You must provide a customEnvironmentUrl when using WPEnvironmentCustom.");
+    
     if (self = [super init])
     {
         self.clientId = clientId;
@@ -55,7 +64,7 @@ restartCardReaderAfterOtherErrors:(BOOL)restartCardReaderAfterOtherErrors
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     
     [dict setValue:self.clientId ? self.clientId : [NSNull null] forKey:@"clientId"];
-    [dict setValue:self.environment ? self.environment : [NSNull null] forKey:@"environment"];
+    [dict setValue:@(self.environment) forKey:@"environment"];
     [dict setValue:@(self.useLocation) forKey:@"useLocation"];
     [dict setValue:@(self.restartCardReaderAfterSuccess) forKey:@"restartCardReaderAfterSuccess"];
     [dict setValue:@(self.restartCardReaderAfterGeneralError) forKey:@"restartCardReaderAfterGeneralError"];

--- a/WePay/Models/WPPaymentInfo.h
+++ b/WePay/Models/WPPaymentInfo.h
@@ -8,6 +8,15 @@
 
 #import <Foundation/Foundation.h>
 #import "WPAddress.h"
+
+// Payment Methods
+typedef NS_ENUM(NSInteger, WPPaymentMethod) {
+    WPPaymentMethodSwipe,
+    WPPaymentMethodManual
+};
+
+extern NSString * NSStringFromWPPaymentMethod(WPPaymentMethod paymentMethod);
+
 /** 
  *  An instance of this class represents the payment information obtained from the user via any of the supported payment methods. It is used as input for tokenization operations.
  */
@@ -49,9 +58,9 @@
 @property (nonatomic, strong, readonly) WPAddress *shippingAddress;
 
 /**
- *  The payment method used, one of (kWPPaymentMethodManual, kWPPaymentMethodSwipe).
+ *  The payment method used, one of (WPPaymentMethodManual, WPPaymentMethodSwipe).
  */
-@property (nonatomic, strong, readonly) id paymentMethod;
+@property (nonatomic, assign, readonly) enum WPPaymentMethod paymentMethod;
 
 /**
  *  Additional info obtained by using the Swipe payment method.

--- a/WePay/Models/WPPaymentInfo.h
+++ b/WePay/Models/WPPaymentInfo.h
@@ -82,7 +82,7 @@ extern NSString * NSStringFromWPPaymentMethod(WPPaymentMethod paymentMethod);
 - (instancetype) initWithSwipedInfo:(id)swipedInfo;
 
 /**
- *  Initializes a WPPaymentInfo instance of type \ref kWPPaymentMethodManual.
+ *  Initializes a WPPaymentInfo instance of type \ref WPPaymentMethodManual.
  *
  *  @param firstName       First name of the payer.
  *  @param lastName        Last name of the payer.

--- a/WePay/Models/WPPaymentInfo.m
+++ b/WePay/Models/WPPaymentInfo.m
@@ -9,6 +9,15 @@
 #import "WPPaymentInfo.h"
 #import "WePay.h"
 
+extern NSString * NSStringFromWPPaymentMethod(WPPaymentMethod paymentMethod) {
+    switch (paymentMethod) {
+        case WPPaymentMethodManual:
+            return @"Manual";
+        case WPPaymentMethodSwipe:
+            return @"Swipe";
+    }
+}
+
 @interface WPPaymentInfo ()
 
 @property (nonatomic, strong, readwrite) NSString *firstName;
@@ -16,7 +25,7 @@
 @property (nonatomic, strong, readwrite) NSString *email;
 @property (nonatomic, strong, readwrite) NSString *paymentDescription;
 @property (nonatomic, readwrite) BOOL isVirtualTerminal;
-@property (nonatomic, strong, readwrite) id paymentMethod;
+@property (nonatomic, assign, readwrite) enum WPPaymentMethod paymentMethod;
 @property (nonatomic, strong, readwrite) WPAddress *billingAddress;
 @property (nonatomic, strong, readwrite) WPAddress *shippingAddress;
 @property (nonatomic, strong, readwrite) id swiperInfo;
@@ -35,7 +44,7 @@
         self.lastName = (NSString *)[info objectForKey:@"lastName"];
         self.paymentDescription = (NSString *)[info objectForKey:@"paymentDescription"];
         self.swiperInfo = [info objectForKey:@"swiperInfo"];
-        self.paymentMethod = kWPPaymentMethodSwipe;
+        self.paymentMethod = WPPaymentMethodSwipe;
     }
     
     return self;
@@ -57,7 +66,7 @@
         self.lastName = lastName;
         self.email = email;
         self.paymentDescription = nil;
-        self.paymentMethod = kWPPaymentMethodManual;
+        self.paymentMethod = WPPaymentMethodManual;
         self.isVirtualTerminal = virtualTerminal;
 
         self.billingAddress = billingAddress;
@@ -91,6 +100,8 @@
 
 - (NSDictionary *) toDict
 {
+    NSString *paymentMethodString = NSStringFromWPPaymentMethod(self.paymentMethod);
+    
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     
     [dict setValue:self.firstName           ? self.firstName            : [NSNull null] forKey:@"firstName"];
@@ -98,7 +109,7 @@
     [dict setValue:self.email               ? self.email                : [NSNull null] forKey:@"email"];
 
     [dict setValue:self.paymentDescription  ? self.paymentDescription   : [NSNull null] forKey:@"paymentDescription"];
-    [dict setValue:self.paymentMethod       ? self.paymentMethod        : [NSNull null] forKey:@"paymentMethod"];
+    [dict setValue:self.paymentMethod       ? paymentMethodString       : [NSNull null] forKey:@"paymentMethod"];
 
     [dict setValue:self.billingAddress      ? [self.billingAddress toDict]  : [NSNull null] forKey:@"billingAddress"];
     [dict setValue:self.shippingAddress     ? [self.shippingAddress toDict] : [NSNull null] forKey:@"shippingAddress"];

--- a/WePay/WePay.h
+++ b/WePay/WePay.h
@@ -20,10 +20,6 @@
 @class WPPaymentInfo;
 @class WPPaymentToken;
 
-// Payment Methods
-extern NSString * const kWPPaymentMethodSwipe;
-extern NSString * const kWPPaymentMethodManual;
-
 // Card Reader status
 typedef NS_ENUM(NSInteger, WPCardReaderStatus) {
     WPCardReaderStatusNotConnected,

--- a/WePay/WePay.h
+++ b/WePay/WePay.h
@@ -29,12 +29,14 @@ extern NSString * const kWPPaymentMethodSwipe;
 extern NSString * const kWPPaymentMethodManual;
 
 // Card Reader status
-extern NSString * const kWPCardReaderStatusNotConnected;
-extern NSString * const kWPCardReaderStatusConnected;
-extern NSString * const kWPCardReaderStatusWaitingForSwipe;
-extern NSString * const kWPCardReaderStatusSwipeDetected;
-extern NSString * const kWPCardReaderStatusTokenizing;
-extern NSString * const kWPCardReaderStatusStopped;
+typedef NS_ENUM(NSInteger, WPCardReaderStatus) {
+    WPCardReaderStatusNotConnected,
+    WPCardReaderStatusConnected,
+    WPCardReaderStatusWaitingForSwipe,
+    WPCardReaderStatusSwipeDetected,
+    WPCardReaderStatusTokenizing,
+    WPCardReaderStatusStopped
+};
 
 
 /** \protocol WPTokenizationDelegate
@@ -85,9 +87,9 @@ extern NSString * const kWPCardReaderStatusStopped;
 /**
  *  Called when the card reader changes status.
  *
- *  @param status Current status of the card reader, one of (kWPCardReaderStatusNotConnected, kWPCardReaderStatusConnected, kWPCardReaderStatusWaitingForSwipe, kWPCardReaderStatusSwipeDetected, kWPCardReaderStatusTokenizing, kWPCardReaderStatusStopped).
+ *  @param status Current status of the card reader, one of (WPCardReaderStatusNotConnected, WPCardReaderStatusConnected, WPCardReaderStatusWaitingForSwipe, WPCardReaderStatusSwipeDetected, WPCardReaderStatusTokenizing, WPCardReaderStatusStopped).
  */
-- (void) cardReaderDidChangeStatus:(id)status;
+- (void) cardReaderDidChangeStatus:(enum WPCardReaderStatus)status;
 
 
 @end

--- a/WePay/WePay.h
+++ b/WePay/WePay.h
@@ -20,10 +20,6 @@
 @class WPPaymentInfo;
 @class WPPaymentToken;
 
-// Environments
-extern NSString * const kWPEnvironmentStage;
-extern NSString * const kWPEnvironmentProduction;
-
 // Payment Methods
 extern NSString * const kWPPaymentMethodSwipe;
 extern NSString * const kWPPaymentMethodManual;

--- a/WePay/WePay.h
+++ b/WePay/WePay.h
@@ -177,7 +177,7 @@ typedef NS_ENUM(NSInteger, WPCardReaderStatus) {
  *  - an unexpected error occurs
  *  - stopCardReader is called
  *
- *  However, if a general error (domain:kWPErrorCategoryCardReader, errorCode:WPErrorCardReaderGeneralError) occurs while reading, after a few seconds delay, the card reader will automatically start waiting again for another 60 seconds. At that time, WPCardReaderDelegate's cardReaderDidChangeStatus: method will be called with kWPCardReaderStatusWaitingForSwipe, and the user can try to use the card reader again. This behavior can be configured with \ref WPConfig.
+ *  However, if a general error (domain:kWPErrorCategoryCardReader, errorCode:WPErrorCardReaderGeneralError) occurs while reading, after a few seconds delay, the card reader will automatically start waiting again for another 60 seconds. At that time, WPCardReaderDelegate's cardReaderDidChangeStatus: method will be called with WPCardReaderStatusWaitingForSwipe, and the user can try to use the card reader again. This behavior can be configured with \ref WPConfig.
  *
  *  WARNING: When this method is called, a (normally inaudible) signal is sent to the headphone jack of the phone, where the card reader is expected to be connected. If headphones are connected instead of the card reader, they may emit a very loud audible tone on receiving this signal. This method should only be called when the user intends to use the card reader.
  *
@@ -193,7 +193,7 @@ typedef NS_ENUM(NSInteger, WPCardReaderStatus) {
  *  - an unexpected error occurs
  *  - stopCardReader is called
  *
- *  However, if a general error (domain:kWPErrorCategoryCardReader, errorCode:WPErrorCardReaderGeneralError) occurs while reading, after a few seconds delay, the card reader will automatically start waiting again for another 60 seconds. At that time, WPCardReaderDelegate's cardReaderDidChangeStatus: method will be called with kWPCardReaderStatusWaitingForSwipe, and the user can try to use the card reader again. This behavior can be configured with \ref WPConfig.
+ *  However, if a general error (domain:kWPErrorCategoryCardReader, errorCode:WPErrorCardReaderGeneralError) occurs while reading, after a few seconds delay, the card reader will automatically start waiting again for another 60 seconds. At that time, WPCardReaderDelegate's cardReaderDidChangeStatus: method will be called with WPCardReaderStatusWaitingForSwipe, and the user can try to use the card reader again. This behavior can be configured with \ref WPConfig.
  *
  *  WARNING: When this method is called, a (normally inaudible) signal is sent to the headphone jack of the phone, where the card reader is expected to be connected. If headphones are connected instead of the card reader, they may emit a very loud audible tone on receiving this signal. This method should only be called when the user intends to use the card reader.
  *
@@ -204,7 +204,7 @@ typedef NS_ENUM(NSInteger, WPCardReaderStatus) {
                                        tokenizationDelegate:(id<WPTokenizationDelegate>) tokenizationDelegate;
 
 /**
- *  Stops the card reader. In response, WPCardReaderDelegate's cardReaderDidChangeStatus: method will be called with kWPCardReaderStatusStopped.
+ *  Stops the card reader. In response, WPCardReaderDelegate's cardReaderDidChangeStatus: method will be called with WPCardReaderStatusStopped.
  *  Any tokenization in progress will not be stopped, and its result will be delivered to the WPTokenizationDelegate.
  */
 - (void) stopCardReader;

--- a/WePay/WePay.m
+++ b/WePay/WePay.m
@@ -18,11 +18,6 @@
 #import "WePay_Checkout.h"
 #import "WPRiskHelper.h"
 
-
-// Payment Methods
-NSString * const kWPPaymentMethodSwipe = @"Swipe";
-NSString * const kWPPaymentMethodManual = @"Manual";
-
 @interface WePay ()
 
 @property(nonatomic, strong) WePay_CardReader *wePayCardReader;
@@ -49,7 +44,7 @@ NSString * const kWPPaymentMethodManual = @"Manual";
 - (void) tokenizePaymentInfo:(WPPaymentInfo *)paymentInfo
         tokenizationDelegate:(id<WPTokenizationDelegate>)tokenizationDelegate
 {
-    if ([kWPPaymentMethodManual isEqualToString:paymentInfo.paymentMethod]) {
+    if (paymentInfo.paymentMethod == WPPaymentMethodManual) {
         if (!self.wePayManual) {
             self.wePayManual = [[WePay_Manual alloc] initWithConfig:self.config];
         }
@@ -57,7 +52,7 @@ NSString * const kWPPaymentMethodManual = @"Manual";
         [self.wePayManual tokenizeManualPaymentInfo:paymentInfo
                                tokenizationDelegate:tokenizationDelegate
                                           sessionId:[self getSessionId]];
-    } else if ([kWPPaymentMethodSwipe isEqualToString:paymentInfo.paymentMethod]) {
+    } else if (paymentInfo.paymentMethod == WPPaymentMethodSwipe) {
         if (!self.wePayCardReader) {
             self.wePayCardReader = [[WePay_CardReader alloc] initWithConfig:self.config];
         }

--- a/WePay/WePay.m
+++ b/WePay/WePay.m
@@ -19,10 +19,6 @@
 #import "WPRiskHelper.h"
 
 
-// Environments
-NSString * const kWPEnvironmentStage = @"stage";
-NSString * const kWPEnvironmentProduction = @"production";
-
 // Payment Methods
 NSString * const kWPPaymentMethodSwipe = @"Swipe";
 NSString * const kWPPaymentMethodManual = @"Manual";

--- a/WePay/WePay.m
+++ b/WePay/WePay.m
@@ -27,14 +27,6 @@ NSString * const kWPEnvironmentProduction = @"production";
 NSString * const kWPPaymentMethodSwipe = @"Swipe";
 NSString * const kWPPaymentMethodManual = @"Manual";
 
-// Card Reader status
-NSString * const kWPCardReaderStatusNotConnected = @"card reader not connected";
-NSString * const kWPCardReaderStatusConnected = @"card reader connected";
-NSString * const kWPCardReaderStatusWaitingForSwipe = @"waiting for swipe";
-NSString * const kWPCardReaderStatusSwipeDetected = @"swipe detected";
-NSString * const kWPCardReaderStatusTokenizing = @"tokenizing";
-NSString * const kWPCardReaderStatusStopped = @"stopped";
-
 @interface WePay ()
 
 @property(nonatomic, strong) WePay_CardReader *wePayCardReader;

--- a/WePayTests/WPTestWePay.m
+++ b/WePayTests/WPTestWePay.m
@@ -25,7 +25,7 @@
     [super setUp];
 
     // set up wepay
-    WPConfig *config = [[WPConfig alloc] initWithClientId:@"171482" environment:kWPEnvironmentStage];
+    WPConfig *config = [[WPConfig alloc] initWithClientId:@"171482" environment:WPEnvironmentStage];
     self.wepay = [[WePay alloc] initWithConfig:config];
 
     // reset booleans


### PR DESCRIPTION
I personally find enums to be safer/cleaner to use than string constants and this also allows for a cleaner interop with Swift. 

Let me know what you think. This is would be a breaking change to the API, so I am not sure how you would want to adjust the version if you accept. 

I attempted to run the test suite on the project against these changes but got some build errors, are there any tricks to getting the tests to run?
